### PR TITLE
Full OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Features
 Install
 -------
 Clone and build from source, and the binary will be placed in `bin/lacc`.
-Default include paths assume GNU standard library headers being available, at `/usr/include/x86_64-linux-gnu`.
-To change to some other libc, for example musl, edit [src/lacc.c](src/lacc.c#L231).
+Default include paths on Linux assume GNU standard library headers being available, at `/usr/include/x86_64-linux-gnu`.
+To change to some other Linux libc, for example musl, edit [src/lacc.c](src/lacc.c#L235).
+\*BSD libc needs no special handling.
 
     git clone https://github.com/larmel/lacc.git
     cd lacc
@@ -45,6 +46,7 @@ A custom argument parser is used, and the definition of each option can be found
     -D X[=] Define macro, optionally with a value. For example -DNDEBUG, or
             -D 'FOO(a)=a*2+1'.
     -fPIC   Generate position-independent code.
+    -fno-PIC Disable position-independent code generation.
     -v      Output verbose diagnostic information. This will dump a lot of
             internal state during compilation, and can be useful for debugging.
     --help  Print help text.

--- a/src/lacc.c
+++ b/src/lacc.c
@@ -100,6 +100,8 @@ static void option(const char *arg)
 {
     if (!strcmp("-fPIC", arg)) {
         context.pic = 1;
+    } else if (!strcmp("-fno-PIC", arg)) {
+        context.pic = 0;
     } else assert(0);
 }
 
@@ -174,6 +176,7 @@ static char *parse_program_arguments(int argc, char *argv[])
         {"-v", &flag},
         {"-w", &flag},
         {"-fPIC", &option},
+        {"-fno-PIC", &option},
         {"--help", &help},
         {"-o:", &open_output_handle},
         {"-I:", &add_include_search_path},
@@ -190,7 +193,14 @@ static char *parse_program_arguments(int argc, char *argv[])
     program = argv[0];
     output = stdout;
     context.standard = STD_C89;
+
+    /* OpenBSD defaults to -fPIC unless explicitly turned off.  */
+#ifdef __OpenBSD__
+    context.pic = 1;
+#endif
+
     context.target = TARGET_IR_DOT;
+
     c = parse_args(sizeof(optv)/sizeof(optv[0]), optv, argc, argv);
     if (c == argc - 1) {
         input = argv[c];
@@ -228,7 +238,9 @@ static void add_include_search_paths(void)
 {
     add_include_search_path("/usr/local/include");
     add_include_search_path(LACC_STDLIB_PATH);
+#ifdef __linux__
     add_include_search_path("/usr/include/x86_64-linux-gnu");
+#endif
     add_include_search_path("/usr/include");
 }
 

--- a/src/preprocessor/macro.c
+++ b/src/preprocessor/macro.c
@@ -837,6 +837,17 @@ INTERNAL void register_builtin_definitions(enum cstd version)
 #ifdef __unix__
     register_macro("__unix__", XSTR(__unix__));
 #endif
+#ifdef __OpenBSD__
+    register_macro("__OpenBSD__", XSTR(__OpenBSD__));
+    if (version == STD_C89) {
+        register_macro("__restrict", "");
+        register_macro("__restrict__", "");
+        register_macro("__ISO_C_VISIBLE", "1990");
+    } else {
+        register_macro("__restrict", "restrict");
+        register_macro("__restrict__", "restrict");
+    }
+#endif
 
     switch (version) {
     case STD_C89:

--- a/src/preprocessor/tokenize.c
+++ b/src/preprocessor/tokenize.c
@@ -533,7 +533,7 @@ static struct token strtoident(const char *in, const char **endptr)
     case '_':
         if (S4('B', 'o', 'o', 'l')) MATCH(BOOL);
         if (S7('A', 'l', 'i', 'g', 'n', 'o', 'f')) MATCH(ALIGNOF);
-        if (!strncmp(in, "Static_assert", 12)) {
+        if (!strncmp(in, "Static_assert", 13)) {
             ident = basic_token[STATIC_ASSERT];
             ident.d.string = str_init("_Static_assert");
             *endptr = start + ident.d.string.len;

--- a/test/c11/static-assert.c
+++ b/test/c11/static-assert.c
@@ -4,6 +4,11 @@
 
 #include <assert.h>
 
+/* NOT actually on OpenBSD! (This is a bug) */
+#ifdef __OpenBSD__
+#define static_assert _Static_assert
+#endif
+
 _Static_assert('a' < 'b', "Alphabet error");
 
 int foo(char a) {


### PR DESCRIPTION
Hi --

This patch adds complete support for OpenBSD. It does so by doing the following:
1. Registers an `__OpenBSD__` preprocessor macro on OpenBSD, like lacc does with `__linux__` and `__unix__`.
2. Disables adding the default include path of `/usr/include/x86_64-linux-gnu` when not on Linux. On all the BSDs, the proper includes are simply in `/usr/include`.
3. Sets up a proper environment when on OpenBSD. OpenBSD defaults to `-fPIC` unless explicitly disabled. On other systems, there is no change.
4. Adds an `-fno-PIC` flag to explicitly disable pic generation.
5. Adds support for the `__restrict` and `__restrict__` synonyms for C99 `restrict` keyword (see: https://gcc.gnu.org/onlinedocs/gcc/Restricted-Pointers.html). All the BSDs use the `__restrict` form in their headers (for example, in `stdio.h`) and gcc, clang, pcc, and cparser all support these synonyms, even though it is technically a GNU extension.
6. Defaults OpenBSD to `-std=c99` because of the `__restrict` keyword use.

This is good enough to run `gmake bin/selfhost` successfully on OpenBSD. But not all is 100%, as there is a code generation bug in the selfhost binary. When building the selfhost binary with the bootstrap binary, this warning is produced:
```
bin/bootstrap -fPIC -I include/ -D'LACC_STDLIB_PATH="/home/brian/lacc/include/stdlib"' -c src/backend/x86_64/instr.c -o bin/backend/x86_64/instr-selfhost.o
(src/backend/x86_64/instr.c, 187) warning: Conversion of decimal constant to unsigned.
```
This is the only warning generated in the entire build process; the warning is not emitted in the lacc binary building the bootstrap binary stage. This appears to matter greatly, as it triggers an assertion for some tests when running `gmake test-selfhost`. For example:
```
assertion "0" failed: file "src/backend/x86_64/instr.c", line 427, function "encode_sub"
Abort trap (core dumped)
assertion "0" failed: file "src/backend/x86_64/instr.c", line 427, function "encode_sub"
Abort trap (core dumped)
[-E: Ok!] [-S: Ok!] [-c: Compilation failed!] [-c -O1: Compilation failed!] :: test/c99/flexible-array.c
```
Let me know if there's anything else you need from me.

Additionally, there is a tiny bug fix: in `src/preprocessor/tokenize.c` there was an off by 1 in the Static_assert strncmp check (12 instead of 13). Test still passes:
`[-E: Ok!] [-S: Ok!] [-c: Ok!] [-c -O1: Ok!] :: test/c11/static-assert.c`