### PR TITLE
Proof of concept linker module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SOURCES = \
 	src/backend/x86_64/assemble.c \
 	src/backend/compile.c \
 	src/backend/graphviz/dot.c \
+	src/backend/linker.c \
 	src/optimizer/transform.c \
 	src/optimizer/liveness.c \
 	src/optimizer/optimize.c \

--- a/include/lacc/context.h
+++ b/include/lacc/context.h
@@ -10,6 +10,7 @@ enum target {
     TARGET_NONE,
     TARGET_IR_DOT,
     TARGET_x86_64_ASM,
+    TARGET_x86_64_BIN,
     TARGET_x86_64_ELF
 };
 

--- a/src/backend/compile.c
+++ b/src/backend/compile.c
@@ -3132,6 +3132,7 @@ INTERNAL void set_compile_target(FILE *stream, const char *file)
 {
     switch (context.target) {
     case TARGET_NONE:
+    case TARGET_x86_64_BIN:
         break;
     case TARGET_IR_DOT:
         dot_init(stream);
@@ -3164,6 +3165,7 @@ INTERNAL int compile(struct definition *def)
     case TARGET_IR_DOT:
         dotgen(def);
     case TARGET_NONE:
+    case TARGET_x86_64_BIN:
         break;
     case TARGET_x86_64_ASM:
     case TARGET_x86_64_ELF:

--- a/src/backend/linker.c
+++ b/src/backend/linker.c
@@ -1,0 +1,118 @@
+#if !AMALGAMATION
+# define INTERNAL
+# define EXTERNAL extern
+#endif
+#include "linker.h"
+
+#include <sys/wait.h>
+
+#include <limits.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+
+static FILE *ld_output;
+static const char *ld_name;
+
+struct ld_args {
+    char *arg;
+    struct ld_args *next;
+};
+static struct ld_args *ld_head;
+
+INTERNAL void init_linker(FILE *output, const char *name)
+{
+    char buf[PATH_MAX];
+
+    ld_output = output;
+    if (output == stdout)
+        ld_name = "a.out";
+    else
+        ld_name = name;
+
+    strncpy(buf, "/usr/bin/ld", PATH_MAX);
+
+    if ((ld_head = malloc(sizeof(struct ld_args))) == NULL) {
+        error("Could not allocate ld argument list.");
+        exit(1);
+    }
+    ld_head->arg = strdup("/usr/bin/ld");
+    ld_head->next = NULL;
+
+    /* Is there a way to generalize? */
+#ifdef __OpenBSD__
+    linker_option("-e");
+    linker_option("__start");
+    linker_option("--eh-frame-hdr");
+    linker_option("-Bdynamic");
+    linker_option("-dynamic-linker");
+    linker_option("/usr/libexec/ld.so");
+    linker_option("-o");
+    linker_option(ld_name);
+    linker_option("/usr/lib/crt0.o");
+    linker_option("/usr/lib/crtbegin.o");
+    linker_option("-L/usr/local/lib");
+    linker_option("-L/usr/lib");
+    linker_option("-lc");
+    linker_option("/usr/lib/crtend.o");
+#endif
+}
+
+INTERNAL void linker_option(const char *opt)
+{
+    struct ld_args *curr;
+
+    curr = ld_head;
+    while (curr->next != NULL)
+        curr = curr->next;
+
+    if ((curr->next = malloc(sizeof(struct ld_args))) == NULL) {
+        error("Could not allocate ld argument.");
+        exit(1);
+    }
+
+    curr = curr->next;
+    curr->arg = strdup(opt);
+    curr->next = NULL;
+}
+
+INTERNAL int linker(void)
+{
+    struct ld_args *curr;
+    char **ld_argv, **temp_argv;
+    int ld_argc = 0, ret, status;
+    pid_t pid;
+
+    curr = ld_head;
+    while (curr != NULL) {
+        ++ld_argc;
+        curr = curr->next;
+    }
+
+    if ((ld_argv = malloc((ld_argc + 1) * sizeof(char **))) == NULL) {
+        error("Could not build ld command.");
+        exit(1);
+    }
+    temp_argv = ld_argv;
+
+    curr = ld_head;
+    while (curr != NULL) {
+        *temp_argv++ = strdup(curr->arg);
+        curr = curr->next;
+    }
+    *temp_argv = NULL;
+
+    switch ((pid = fork())) {
+    case -1:
+        error("ld command failed.");
+        exit(1);
+    case 0:
+        execvp(ld_argv[0], ld_argv);
+        _exit(0);
+    default:
+        waitpid(pid, &status, 0);
+        ret = WEXITSTATUS(status);
+    }
+
+    return ret;
+}

--- a/src/backend/linker.h
+++ b/src/backend/linker.h
@@ -1,0 +1,15 @@
+#ifndef LINKER_H
+#define LINKER_H
+
+#include <stdio.h>
+
+/* Call once on startup, with output handle and file name. */
+INTERNAL void init_linker(FILE *output, const char *name);
+
+/* Add an option to be passed to the linker. */
+INTERNAL void linker_option(const char *opt);
+
+/* Call the linker. */
+INTERNAL int linker(void);
+
+#endif


### PR DESCRIPTION
Hi --

This is not really intended to be integrated as-is, but here's a very quick and dirty patch that lets `lacc` be a totally self-reliant compiler.

With this patch, I am able to compile OpenBSD `ed(1)` on OpenBSD with `lacc`. See https://github.com/ibara/oed -- it requires a special `Makefile` to build, due to `lacc` breaking the (GNU?) assumption that `-c` without `-o` implies an output file the same as the input file but with the extension changed from `.c` to `.o`.

One downside to this patch is that `lacc` cannot build itself anymore: it dies on `linker.c:35`.

Putting it here as to be a starting point for discussion on a better/proper implementation. Having `lacc` call the linker itself I see as a positive, since it moves `lacc` closer to being usable by `configure` scripts and `Makefile`s and the like without manual editing.