### PR TITLE
Add __asm macro synonym for __asm__.

### DIFF
--- a/src/preprocessor/macro.c
+++ b/src/preprocessor/macro.c
@@ -874,6 +874,8 @@ INTERNAL void register_builtin_definitions(enum cstd version)
     }
 #endif
 
+    register_macro("__asm", "__asm__");
+
     switch (version) {
     case STD_C89:
         break;


### PR DESCRIPTION
According to
https://github.com/gcc-mirror/gcc/blob/gcc-8_1_0-release/gcc/c-family/c-common.c#L364
__asm is a synonym for __asm__.

And sure enough, OpenBSD uses __asm. This pull request unbreaks the OpenBSD build.