### PR TITLE
Add -MD, -MT, -static, and -[no]pie flag recognition to the driver.

### DIFF
--- a/src/lacc.c
+++ b/src/lacc.c
@@ -400,9 +400,13 @@ static int parse_program_arguments(int argc, char *argv[])
         {"--dump-symbols", &long_option},
         {"--dump-types", &long_option},
         {"-pipe", &option},
+        {"-MD", &option},
+        {"-MP", &option},
         {"-Wl,", &add_linker_flag},
         {"-rdynamic", &add_linker_flag},
         {"-shared", &add_linker_arg},
+        {"-static", &add_linker_arg},
+        {"-[no]pie", &add_linker_arg},
         {"-l:", &add_linker_library},
         {"-L:", &add_linker_path},
         {NULL, &add_input_file}


### PR DESCRIPTION
This PR adds some extra flag recognition to the driver that the OpenBSD build system expects. It doesn't actually do anything with -MD or -MT but -static and -[no]pie are required linker flags for OpenBSD builds. Unfortunately, OpenBSD calls the option to disable PIE linking -nopie whereas Linux names it -no-pie. I'm not sure how to reconcile that difference; I tried -[no[-]]pie but that didn't seem to work.