### PR TITLE
The -W flag means -Wextra

### DIFF
--- a/src/util/argparse.c
+++ b/src/util/argparse.c
@@ -106,7 +106,9 @@ static int match_arg(struct option opt, int argc, char *argv[], int *ret)
         rulelen -= 1;
     case '=':
         if (!strncmp(opt.rule, argv[0], rulelen)) {
-            if (arglen == rulelen) {
+            if (!strcmp(argv[0], "-W")) {
+                argv[0] = "-Wextra";
+            } else if (arglen == rulelen) {
                 fprintf(stderr, "Missing argument to %s.\n", argv[0]);
                 *ret = 1;
                 return 0;


### PR DESCRIPTION
Hi --

The -W flag is a (allegedly deprecated) synonym for -Wextra. Both gcc and clang recognize -W.
lacc however will complain that -W is missing an argument. This PR teaches lacc about -W. It still may be the case that -Wextra gets ignored for now, but that's preferable to a compiler error.