### PR TITLE
Modified for typedef of imcomplete array.

### DIFF
--- a/src/parser/declaration.c
+++ b/src/parser/declaration.c
@@ -354,7 +354,11 @@ static struct block *direct_declarator(
         consume(')');
         break;
     default:
-        *type = base;
+        if (base.type == T_ARRAY && is_complete(base)) {
+            *type = type_copy_incomplete(base);
+        } else {
+            *type = base;
+        }
         break;
     }
 

--- a/src/parser/expression.c
+++ b/src/parser/expression.c
@@ -505,6 +505,9 @@ exprsize:   head = cfg_block_init(def);
             tail = unary_expression(def, head);
             type = tail->expr.type;
         }
+        if (!is_complete(type) && is_array(type) && size_of(type)) {
+            set_array_length(type, type_array_len(type));
+        }
         if (is_complete(type)) {
             if (is_vla(type)) {
                 block->expr = eval_vla_size(def, block, type);

--- a/src/parser/initializer.c
+++ b/src/parser/initializer.c
@@ -421,7 +421,7 @@ static struct block *initialize_array(
     assert(target.kind == DIRECT);
 
     i = c = 0;
-    count = type_array_len(target.type);
+    count = is_complete(target.type) ? type_array_len(target.type) : 0;
     type = target.type;
     elem = type_next(type);
     width = size_of(elem);
@@ -469,9 +469,8 @@ static struct block *initialize_array(
         }
     }
 
-    if (!size_of(type)) {
+    if (!is_complete(type) || !size_of(type)) {
         assert(is_array(target.symbol->type));
-        assert(!size_of(target.symbol->type));
         set_array_length(target.symbol->type, c);
     }
 
@@ -729,7 +728,9 @@ static void initialize_trailing_padding(
     size_t size,
     size_t bitfield_size)
 {
-    assert(size >= target.offset);
+    if (size <= target.offset) {
+        return;
+    }
 
     if (target.field_offset) {
         switch (bitfield_size) {

--- a/src/parser/typetree.c
+++ b/src/parser/typetree.c
@@ -1105,13 +1105,31 @@ INTERNAL Type type_next(Type type)
     return t->next;
 }
 
+INTERNAL Type type_copy_incomplete(Type type)
+{
+    struct typetree *tb, *tn;
+    Type tp = type_create(type.type);
+    tp.is_const = type.is_const;
+    tp.is_pointer = type.is_pointer;
+    tp.is_pointer_const = type.is_pointer_const;
+    tp.is_pointer_restrict = type.is_pointer_restrict;
+    tp.is_pointer_volatile = type.is_pointer_volatile;
+    tp.is_restrict = type.is_restrict;
+    tp.is_unsigned = type.is_unsigned;
+    tp.is_volatile = type.is_volatile;
+    tb = get_typetree_handle(type.ref);
+    tn = get_typetree_handle(tp.ref);
+    *tn = *tb;
+    tn->is_incomplete = 1;
+    return tp;
+}
+
 INTERNAL void set_array_length(Type type, size_t length)
 {
     struct typetree *t;
     assert(is_array(type));
 
     t = get_typetree_handle(type.ref);
-    assert(!t->size);
     assert(t->is_incomplete);
     t->size = length;
     t->is_incomplete = 0;

--- a/src/parser/typetree.h
+++ b/src/parser/typetree.h
@@ -26,6 +26,7 @@ INTERNAL Type type_create_function(Type next);
 INTERNAL Type type_create_array(Type next, size_t count);
 INTERNAL Type type_create_incomplete(Type next);
 INTERNAL Type type_create_vla(Type next, const struct symbol *count);
+INTERNAL Type type_copy_incomplete(Type type);
 
 /* Add const, volatile, and restrict qualifiers to type. */
 INTERNAL Type type_set_const(Type type);

--- a/test/typedef-incomplete-array.c
+++ b/test/typedef-incomplete-array.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+static void test_typedef()
+{
+    typedef int A[];
+    A a = { 1, 2 };
+    A b = { 3, 4, 5 };
+    printf("exp:%d, val:%d\n", 2, sizeof(a) / sizeof(*a));
+    printf("exp:%d, val:%d\n" ,3, sizeof(b) / sizeof(*b));
+}
+
+int main(void)
+{
+    test_typedef();
+    return 0;
+}
+


### PR DESCRIPTION
Hello, larmel.

Thank you for your very good compiler. Now I am using your compiler inside my product because I think it is the best choice.

If you have an interest in it, please see [kcci-platform](https://github.com/Kray-G/kcci-platform).

It is wonderful for me, but unfortunately I have used the old code because my project was started a year ago. Now I can't use the latest code... sorry but I will be going to maintain it.

Anyway, I would like to feedback something for you from what I have faced in my development with your product.

Here is the problem code. ex) `test/typedef-incomplete-array.c`.

```c
#include <stdio.h>

static void test_typedef()
{
    typedef int A[];
    A a = { 1, 2 };
    A b = { 3, 4, 5 };
    printf("exp:%d, val:%d\n", 2, sizeof(a) / sizeof(*a));
    printf("exp:%d, val:%d\n" ,3, sizeof(b) / sizeof(*b));
}

int main(void)
{
    test_typedef();
    return 0;
}
```

I got the following message.

```
(test/typedef-incomplete-array.c, 7) error: Expected } but got 5.
```

[C89/C90/C99 standard](http://c0x.coding-guidelines.com/6.7.8.html) says:

> One form of initialization that completes array types involves typedef names. Given the declaration
> 
> ```c
> typedef int A[];        // OK - declared with block scope
> ```
> 
> the declaration
> 
> ```c
> A a = { 1, 2 }, b = { 3, 4, 5 };
> ```
> 
> is identical to
> 
> ```c
> int a[] = { 1, 2 }, b[] = { 3, 4, 5 };
> ```
> 
> due to the rules for incomplete types.
> 

Therefore the result should be:

```
exp:2, val:2
exp:3, val:3
```
