### PR TITLE
Add a --version flag

### DIFF
--- a/src/lacc.c
+++ b/src/lacc.c
@@ -104,6 +104,12 @@ static int help(const char *arg)
     return 1;
 }
 
+static int version(const char *arg)
+{
+    fprintf(stderr, "lacc 1.0.0 (%s)\n", __DATE__);
+    return 1;
+}
+
 static int flag(const char *arg)
 {
     assert(arg[0] == '-');
@@ -484,6 +490,7 @@ static int parse_program_arguments(int argc, char *argv[])
         {"-m[no-]mmx", &option},
         {"-dot", &option},
         {"--help", &help},
+        {"--version", &version},
         {"-march=", &set_cpu},
         {"-o:", &set_output_name},
         {"-I:", &add_include_search_path},


### PR DESCRIPTION
mksh's build script needs the compiler to output some sort of version information in a flag in order to properly report compiler used. Feel free to change the actual output.