### PR TITLE
docs: fix simple typo, libary -> library

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Running `./fact` followed by `echo $?` should print `120`.
 Implementation
 --------------
 The compiler is written in C89, counting around 19k lines of code in total.
-There are no external dependencies except for the C standard libary, and some system calls required to invoke the linker.
+There are no external dependencies except for the C standard library, and some system calls required to invoke the linker.
 
 The implementation is organized into four main parts; preprocessor, parser, optimizer, and backend, each in their own directory under [src/](src/).
 In general, each module (a `.c` file typically paired with an `.h` file defining the public interface) depend mostly on headers in their own subtree.


### PR DESCRIPTION
There is a small typo in README.md.

Should read `library` rather than `libary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md