### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ test: test-c89 test-c99 test-c11
 test-all: test test-gnu test-asm test-linker test-sqlite
 
 install: bin/release/lacc
-	mkdir -p $(LIBDIR_TARGET)/include/
+	mkdir -p $(LIBDIR_TARGET)/include/ $(BINDIR)
 	cp $(LIBDIR_SOURCE)/include/*.h $(LIBDIR_TARGET)/include/
 	cp $? $(BINDIR)/lacc
 


### PR DESCRIPTION
Steps to reproduce:
```
$ make install PREFIX=~/lacc
mkdir -p /home/sikmir/lacc/lib/lacc/include/
cp /home/sikmir/projects/lacc/bin/include/*.h /home/sikmir/lacc/lib/lacc/include/
cp bin/release/lacc /home/sikmir/lacc/bin/lacc
cp: cannot create regular file '/home/sikmir/lacc/bin/lacc': No such file or directory
make: *** [Makefile:130: install] Error 1
```